### PR TITLE
Add product image overlay extension with local settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# extension
+# Product Image Overlay Extension
+
+A Chrome extension that overlays a semi-transparent layer over product images on any page. It is useful for rapid visual prototyping.
+
+## Features
+
+- Toggle overlay on/off from the popup.
+- Opacity slider to adjust transparency.
+- Live count of images on the current tab.
+- Remembers enabled state and opacity using `chrome.storage.local`.
+
+## Development
+
+1. Open **chrome://extensions** in Chrome.
+2. Enable **Developer mode**.
+3. Choose **Load unpacked** and select this folder.
+4. The extension icon will appear in the toolbar.
+
+## Files
+
+- `manifest.json` – Extension configuration.
+- `background.js` – Initializes default settings.
+- `contentScript.js` – Injects overlays and watches for DOM changes.
+- `overlay.css` – Basic overlay styling.
+- `popup/` – Popup UI code.

--- a/background.js
+++ b/background.js
@@ -1,0 +1,3 @@
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.storage.local.set({ enabled: false, opacity: 0.5 });
+});

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,0 +1,102 @@
+const overlayClass = 'product-image-overlay';
+let enabled = false;
+let opacity = 0.5;
+let imageCount = 0;
+
+const updateCount = () => {
+  const imgs = document.querySelectorAll('img');
+  const newCount = imgs.length;
+  if (newCount !== imageCount) {
+    imageCount = newCount;
+    chrome.runtime.sendMessage({ type: 'COUNT_UPDATE', count: imageCount });
+  }
+};
+
+const applyOverlay = (img) => {
+  const container = img.parentElement;
+  if (!container) return;
+
+  const existing = container.querySelector(`.${overlayClass}`);
+  if (existing) {
+    existing.style.opacity = opacity;
+    return;
+  }
+
+  const computed = window.getComputedStyle(container);
+  if (computed.position === 'static') {
+    container.dataset.originalPosition = 'static';
+    container.style.position = 'relative';
+  }
+
+  const overlay = document.createElement('div');
+  overlay.className = overlayClass;
+  overlay.style.opacity = opacity;
+  container.appendChild(overlay);
+};
+
+const applyToAll = () => {
+  document.querySelectorAll('img').forEach(applyOverlay);
+  updateCount();
+};
+
+const removeAll = () => {
+  document.querySelectorAll(`.${overlayClass}`).forEach((overlay) => {
+    const container = overlay.parentElement;
+    overlay.remove();
+    if (container && container.dataset.originalPosition === 'static') {
+      container.style.position = '';
+      delete container.dataset.originalPosition;
+    }
+  });
+};
+
+const observer = new MutationObserver((mutations) => {
+  updateCount();
+  if (!enabled) return;
+  mutations.forEach((mutation) => {
+    mutation.addedNodes.forEach((node) => {
+      if (node.nodeType !== 1) return;
+      if (node.tagName === 'IMG') {
+        applyOverlay(node);
+      }
+      node.querySelectorAll?.('img').forEach(applyOverlay);
+    });
+  });
+});
+
+observer.observe(document.documentElement, { childList: true, subtree: true });
+
+chrome.storage.local.get(['enabled', 'opacity'], (res) => {
+  enabled = res.enabled;
+  opacity = res.opacity ?? opacity;
+  if (enabled) {
+    applyToAll();
+  } else {
+    updateCount();
+  }
+});
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'ENABLE') {
+    enabled = message.enabled;
+    if (enabled) {
+      applyToAll();
+    } else {
+      removeAll();
+    }
+    updateCount();
+  }
+
+  if (message.type === 'OPACITY') {
+    opacity = message.opacity;
+    if (enabled) {
+      document.querySelectorAll(`.${overlayClass}`).forEach((overlay) => {
+        overlay.style.opacity = opacity;
+      });
+    }
+  }
+
+  if (message.type === 'COUNT_REQUEST') {
+    sendResponse({ count: imageCount });
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,22 @@
+{
+  "manifest_version": 3,
+  "name": "Product Image Overlay",
+  "version": "1.0.0",
+  "description": "Overlay a semi-transparent layer on product images for visual prototyping.",
+  "permissions": ["storage"],
+  "host_permissions": ["<all_urls>"],
+  "action": {
+    "default_popup": "popup/popup.html"
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["contentScript.js"],
+      "css": ["overlay.css"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/overlay.css
+++ b/overlay.css
@@ -1,0 +1,9 @@
+.product-image-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #ff0000;
+  pointer-events: none;
+}

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -1,0 +1,14 @@
+body {
+  min-width: 200px;
+  padding: 10px;
+  font-family: Arial, sans-serif;
+}
+
+label {
+  display: block;
+  margin-bottom: 10px;
+}
+
+#count {
+  margin-bottom: 10px;
+}

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Product Overlay</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <label>
+      <input type="checkbox" id="toggle" /> Enable Overlay
+    </label>
+    <div id="count">Images found: 0</div>
+    <label>
+      Opacity: <input type="range" id="opacity" min="0" max="1" step="0.01" />
+    </label>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,0 +1,43 @@
+const toggle = document.getElementById('toggle');
+const opacitySlider = document.getElementById('opacity');
+const countDiv = document.getElementById('count');
+
+const updateCount = (count) => {
+  countDiv.textContent = `Images found: ${count}`;
+};
+
+chrome.storage.local.get(['enabled', 'opacity'], (res) => {
+  const enabled = res.enabled;
+  toggle.checked = enabled;
+  opacitySlider.value = res.opacity ?? 0.5;
+  opacitySlider.disabled = !enabled;
+
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    chrome.tabs.sendMessage(tabs[0].id, { type: 'COUNT_REQUEST' }, (response) => {
+      if (response) updateCount(response.count);
+    });
+  });
+});
+
+toggle.addEventListener('change', () => {
+  const enabled = toggle.checked;
+  opacitySlider.disabled = !enabled;
+  chrome.storage.local.set({ enabled });
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    chrome.tabs.sendMessage(tabs[0].id, { type: 'ENABLE', enabled });
+  });
+});
+
+opacitySlider.addEventListener('input', () => {
+  const opacity = parseFloat(opacitySlider.value);
+  chrome.storage.local.set({ opacity });
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    chrome.tabs.sendMessage(tabs[0].id, { type: 'OPACITY', opacity });
+  });
+});
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.type === 'COUNT_UPDATE') {
+    updateCount(message.count);
+  }
+});


### PR DESCRIPTION
## Summary
- add MV3 manifest, service worker and content script for product image overlays
- implement popup UI with toggle, live image count and opacity slider
- persist settings via chrome.storage.local and support dynamic DOM changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689482e8cd548321859b07b1e68e20fb