### PR TITLE
feat: overlay product image

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -1,5 +1,7 @@
 const overlayClass = 'product-image-overlay';
 const tileSelector = '[class^="product-list_component_product-list__tile"]';
+const imageSelector = '[class^="image-section_component_image-section__image"]';
+const selectors = [tileSelector, imageSelector];
 let enabled = false;
 let opacity = 0.5;
 let imageCount = 0;
@@ -42,7 +44,9 @@ const applyOverlay = (tile) => {
 };
 
 const applyToAll = () => {
-  document.querySelectorAll(tileSelector).forEach(applyOverlay);
+  selectors.forEach((selector) => {
+    document.querySelectorAll(selector).forEach(applyOverlay);
+  });
   updateCount();
 };
 
@@ -63,10 +67,12 @@ const observer = new MutationObserver((mutations) => {
   mutations.forEach((mutation) => {
     mutation.addedNodes.forEach((node) => {
       if (node.nodeType !== 1) return;
-      if (node.matches?.(tileSelector)) {
-        applyOverlay(node);
-      }
-      node.querySelectorAll?.(tileSelector).forEach(applyOverlay);
+      selectors.forEach((selector) => {
+        if (node.matches?.(selector)) {
+          applyOverlay(node);
+        }
+        node.querySelectorAll?.(selector).forEach(applyOverlay);
+      });
     });
   });
 });

--- a/overlay.css
+++ b/overlay.css
@@ -4,6 +4,6 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background: #808080;
+  background: rgba(0, 0, 0, 0.5);
   pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- overlay list tiles and product detail images with the same semi-transparent layer
- use rgba(0,0,0,0.5) for overlay background

## Testing
- `npm test` *(fails: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68948e184f908321bd1d14abf4d1bc72